### PR TITLE
Add portal PWA install support

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Mumega Portal",
+  "short_name": "Mumega",
+  "description": "Mumega customer portal",
+  "start_url": "/portal/",
+  "scope": "/portal/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/components/PortalInstallPrompt.tsx
+++ b/src/components/PortalInstallPrompt.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+const STORAGE_KEY = 'mumega-portal-install-dismissed'
+
+export function PortalInstallPrompt() {
+  const [installEvent, setInstallEvent] = useState<BeforeInstallPromptEvent | null>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY) === 'true') return
+
+    const onBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault()
+      setInstallEvent(event as BeforeInstallPromptEvent)
+      setVisible(true)
+    }
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    return () => window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+  }, [])
+
+  if (!visible || !installEvent) return null
+
+  const dismiss = () => {
+    localStorage.setItem(STORAGE_KEY, 'true')
+    setVisible(false)
+  }
+
+  const install = async () => {
+    await installEvent.prompt()
+    await installEvent.userChoice
+    dismiss()
+  }
+
+  return (
+    <div className="fixed inset-x-4 bottom-4 z-50 mx-auto max-w-md rounded-2xl border border-slate-700 bg-slate-950 p-4 text-white shadow-2xl">
+      <p className="text-sm font-semibold">Install Mumega Portal</p>
+      <p className="mt-1 text-xs text-slate-300">Add the portal to your home screen for faster customer access.</p>
+      <div className="mt-3 flex gap-2">
+        <button className="rounded-lg bg-white px-3 py-2 text-sm font-medium text-slate-950" onClick={install}>Install</button>
+        <button className="rounded-lg px-3 py-2 text-sm text-slate-300" onClick={dismiss}>Not now</button>
+      </div>
+    </div>
+  )
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import '../styles/base.css'
 import { generateCssVars } from '../lib/theme'
 import { config } from '../lib/config'
 import { CommandPalette } from '../components/navigation/CommandPalette'
+import { PortalInstallPrompt } from '../components/PortalInstallPrompt'
 import JsonLd from '../components/seo/JsonLd.astro'
 import { safeGetCollection } from '../lib/safe-content'
 
@@ -177,10 +178,13 @@ const commandPaletteItems = [
     {analytics.plausible && (
       <script is:inline async defer data-domain={analytics.plausible} src="https://plausible.io/js/script.js"></script>
     )}
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#0f172a" />
   </head>
   <body>
     <slot />
     <CommandPalette client:idle items={commandPaletteItems} />
+    {Astro.url.pathname.startsWith('/portal') && <PortalInstallPrompt client:idle />}
 
     {/* Mermaid diagram rendering — only loads if diagrams exist on the page */}
     <script is:inline>


### PR DESCRIPTION
Fixes #36.\n\n## Summary\n- add a web app manifest for the customer portal\n- link the manifest and theme color from the base layout\n- add a dismissible install prompt island shown on /portal routes\n\n## Verification\n- npm run build\n- git diff --check