### PR TITLE
fix: include squad_id in bounty INSERT statement

### DIFF
--- a/plugins/bounty/routes.ts
+++ b/plugins/bounty/routes.ts
@@ -173,8 +173,8 @@ bountyRoutes.post('/', requireAuth, async (c) => {
   await db.execute(
     `INSERT INTO bounties
        (id, customer_slug, title, description, reward_cents, currency,
-        status, creator_id, labels_json, expires_at, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?)`,
+        status, creator_id, squad_id, labels_json, expires_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?)`,
     [
       id,
       tenant,
@@ -183,6 +183,7 @@ bountyRoutes.post('/', requireAuth, async (c) => {
       body.reward_cents,
       body.currency ?? 'USD',
       session.identityId,
+      body.squad_id ?? null,
       JSON.stringify(body.labels ?? []),
       body.expires_at ?? null,
       ts,


### PR DESCRIPTION
## Summary

Fixes #43 — The  field was silently dropped when creating bounties via .

## Changes

- Added  to the INSERT column list in 
- Added  to the VALUES parameter list

## Root Cause

The  table schema (migration ) includes a  column, and the request body type accepts  as an optional field. However, the INSERT statement was missing  from both the column list and the values array, causing it to be silently ignored.

## Testing

- Verified that the column count matches the value count in the INSERT statement
- The fix preserves backward compatibility —  defaults to  when not provided

## Related

- Issue #43: Bounty: fix squad_id INSERT bug + agent claiming auth
- This PR addresses only the INSERT bug. Agent claiming auth requires additional schema changes (agent_id, assignee_type columns) and middleware work.