### PR TITLE
⚡ Bolt: [performance improvement] Cache Intl.NumberFormat for React Renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-05 - [Cache Intl.NumberFormat for React Renders]
+ **Learning:** Repeatedly instantiating `Intl.NumberFormat` inside React components (especially in lists or frequently updated dashboards) causes unnecessary CPU overhead and garbage collection.
+ **Action:** Always create a centralized caching utility (like a Map) for `Intl.NumberFormat` instances to reuse them across components instead of `new Intl.NumberFormat(...)` on every render.

--- a/plugins/analytics/components/CohortTable.tsx
+++ b/plugins/analytics/components/CohortTable.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { getCompactFormatter } from '../../../src/lib/formatters'
 
 interface Cohort {
   name: string
@@ -79,7 +80,7 @@ export function CohortTable({ days = 30 }: CohortTableProps) {
             <div style={{ padding: '0.8rem 1.5rem', borderBottom: '1px solid var(--ink-border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <span style={{ color: 'var(--ink-muted)', fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Total Visitors</span>
               <span style={{ color: 'var(--ink-text)', fontSize: '1.1rem', fontWeight: 700, fontFamily: 'var(--ink-font-mono, monospace)' }}>
-                {new Intl.NumberFormat('en-CA', { notation: 'compact' }).format(data.totalVisitors)}
+                {getCompactFormatter('en-CA').format(data.totalVisitors)}
               </span>
             </div>
 

--- a/plugins/dashboard/components/ArrowDashboard.tsx
+++ b/plugins/dashboard/components/ArrowDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { getCurrencyFormatter, getCompactFormatter } from '../../../src/lib/formatters'
 import { Card, CardContent, CardHeader, CardTitle } from '../../../src/components/ui/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../src/components/ui/table'
 import { Badge } from '../../../src/components/ui/badge'
@@ -55,11 +56,11 @@ function timeAgo(ts: string): string {
 }
 
 function formatCurrency(n: number): string {
-  return new Intl.NumberFormat('en-CA', { style: 'currency', currency: 'CAD', maximumFractionDigits: 0 }).format(n)
+  return getCurrencyFormatter('en-CA', 'CAD', { maximumFractionDigits: 0 }).format(n)
 }
 
 function formatCompact(n: number): string {
-  return new Intl.NumberFormat('en-CA', { notation: 'compact', maximumFractionDigits: 1 }).format(n)
+  return getCompactFormatter('en-CA', { maximumFractionDigits: 1 }).format(n)
 }
 
 const TEAM_NAMES: Record<string, string> = config.brand?.teamNames || {}

--- a/plugins/dashboard/components/BillingPanel.tsx
+++ b/plugins/dashboard/components/BillingPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { getCurrencyFormatter } from '../../../src/lib/formatters'
 import { Card, CardContent, CardHeader, CardTitle } from '../../../src/components/ui/card'
 import { Badge } from '../../../src/components/ui/badge'
 import { Button } from '../../../src/components/ui/button'
@@ -68,12 +69,7 @@ function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
 }
 
 function formatCurrency(cents: number, currency: string): string {
-  return new Intl.NumberFormat('en-CA', {
-    style: 'currency',
-    currency: currency.toUpperCase(),
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(cents / 100)
+  return getCurrencyFormatter('en-CA', currency.toUpperCase(), { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(cents / 100)
 }
 
 function formatDate(iso: string): string {

--- a/plugins/dashboard/components/LeaguePanel.tsx
+++ b/plugins/dashboard/components/LeaguePanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { getCurrencyFormatter } from '../../../src/lib/formatters'
 import { Card, CardContent } from '../../../src/components/ui/card'
 import { Badge } from '../../../src/components/ui/badge'
 import { Separator } from '../../../src/components/ui/separator'
@@ -47,11 +48,7 @@ function apiFetch(url: string, options?: RequestInit): Promise<Response> {
 }
 
 function formatCurrency(cents: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 2,
-  }).format(cents / 100)
+  return getCurrencyFormatter('en-US', 'USD', { minimumFractionDigits: 2 }).format(cents / 100)
 }
 
 function daysRemaining(endDate: string): number {

--- a/plugins/dashboard/components/SquadPanel.tsx
+++ b/plugins/dashboard/components/SquadPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { getCurrencyFormatter } from '../../../src/lib/formatters'
 import { Card, CardContent, CardHeader, CardTitle } from '../../../src/components/ui/card'
 import { Badge } from '../../../src/components/ui/badge'
 import { Progress } from '../../../src/components/ui/progress'
@@ -20,11 +21,7 @@ interface KPIData {
 // ── KPI formatters ─────────────────────────────────────────────────────────
 
 function formatMoney(cents: number): string {
-  return new Intl.NumberFormat('en-CA', {
-    style: 'currency',
-    currency: 'CAD',
-    maximumFractionDigits: 0,
-  }).format(cents / 100)
+  return getCurrencyFormatter('en-CA', 'CAD', { maximumFractionDigits: 0 }).format(cents / 100)
 }
 
 function formatTokens(n: number): string {

--- a/plugins/dashboard/components/WalletView.tsx
+++ b/plugins/dashboard/components/WalletView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { getCurrencyFormatter } from '../../../src/lib/formatters'
 import { Card, CardContent, CardHeader, CardTitle } from '../../../src/components/ui/card'
 import { Badge } from '../../../src/components/ui/badge'
 import { Button } from '../../../src/components/ui/button'
@@ -53,12 +54,7 @@ function humanizeReason(reason: string, type: 'earn' | 'spend'): string {
 }
 
 function formatCAD(n: number): string {
-  return new Intl.NumberFormat('en-CA', {
-    style: 'currency',
-    currency: 'CAD',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(n)
+  return getCurrencyFormatter('en-CA', 'CAD', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n)
 }
 
 function formatDate(iso: string): string {

--- a/plugins/portal/components/InvoicesView.tsx
+++ b/plugins/portal/components/InvoicesView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { getCurrencyFormatter } from '../../../src/lib/formatters'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -31,11 +32,7 @@ async function apiFetch(url: string, options?: RequestInit): Promise<Response> {
 }
 
 function formatCurrency(amount: number, currency = 'CAD'): string {
-  return new Intl.NumberFormat('en-CA', {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 2,
-  }).format(amount)
+  return getCurrencyFormatter('en-CA', currency, { minimumFractionDigits: 2 }).format(amount)
 }
 
 function formatDate(dateStr: string): string {

--- a/src/components/charts/DataTable.tsx
+++ b/src/components/charts/DataTable.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { getCurrencyFormatter, getCompactFormatter } from '../../lib/formatters'
 
 interface Column {
   key: string
@@ -20,9 +21,9 @@ function formatCell(value: unknown, format: Column['format']): string {
   if (value === null || value === undefined) return '—'
   switch (format) {
     case 'number':
-      return new Intl.NumberFormat('en-CA', { notation: 'compact', maximumFractionDigits: 1 }).format(value as number)
+      return getCompactFormatter('en-CA', { maximumFractionDigits: 1 }).format(value as number)
     case 'currency':
-      return new Intl.NumberFormat('en-CA', { style: 'currency', currency: 'CAD', maximumFractionDigits: 0 }).format(value as number)
+      return getCurrencyFormatter('en-CA', 'CAD', { maximumFractionDigits: 0 }).format(value as number)
     case 'percent':
       return `${(value as number).toFixed(1)}%`
     default:

--- a/src/components/charts/KPICard.tsx
+++ b/src/components/charts/KPICard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { getCurrencyFormatter, getCompactFormatter } from '../../lib/formatters'
 
 interface KPICardProps {
   title: string
@@ -13,11 +14,11 @@ function formatValue(value: number, format: KPICardProps['format']): string {
   if (value === null || value === undefined) return '—'
   switch (format) {
     case 'currency':
-      return new Intl.NumberFormat('en-CA', { style: 'currency', currency: 'CAD', maximumFractionDigits: 0 }).format(value)
+      return getCurrencyFormatter('en-CA', 'CAD', { maximumFractionDigits: 0 }).format(value)
     case 'percent':
       return `${value.toFixed(1)}%`
     default:
-      return new Intl.NumberFormat('en-CA', { notation: 'compact', maximumFractionDigits: 1 }).format(value)
+      return getCompactFormatter('en-CA', { maximumFractionDigits: 1 }).format(value)
   }
 }
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,0 +1,42 @@
+/**
+ * Cache Intl.NumberFormat instances to avoid performance overhead
+ * of creating new instances repeatedly, particularly during renders.
+ */
+const formatters = new Map<string, Intl.NumberFormat>();
+
+function getFormatterKey(locale: string, options: Intl.NumberFormatOptions = {}): string {
+  // Sort keys to ensure consistent cache keys regardless of object creation order
+  const sortedOptions = Object.keys(options)
+    .sort()
+    .reduce((acc, key) => {
+      acc[key as keyof Intl.NumberFormatOptions] = options[key as keyof Intl.NumberFormatOptions];
+      return acc;
+    }, {} as Intl.NumberFormatOptions);
+
+  return `${locale}-${JSON.stringify(sortedOptions)}`;
+}
+
+export function getFormatter(locale: string, options: Intl.NumberFormatOptions = {}): Intl.NumberFormat {
+  const key = getFormatterKey(locale, options);
+  let formatter = formatters.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, options);
+    formatters.set(key, formatter);
+  }
+  return formatter;
+}
+
+export function getCurrencyFormatter(
+  locale: string = 'en-CA',
+  currency: string = 'CAD',
+  options: Intl.NumberFormatOptions = {}
+): Intl.NumberFormat {
+  return getFormatter(locale, { style: 'currency', currency, ...options });
+}
+
+export function getCompactFormatter(
+  locale: string = 'en-CA',
+  options: Intl.NumberFormatOptions = {}
+): Intl.NumberFormat {
+  return getFormatter(locale, { notation: 'compact', ...options });
+}


### PR DESCRIPTION
💡 What: Created `src/lib/formatters.ts` to cache `Intl.NumberFormat` instances and updated various components (KPI cards, data tables, dashboards) to use the new `getCurrencyFormatter` and `getCompactFormatter` functions.
🎯 Why: Instantiating `Intl.NumberFormat` is computationally expensive and causes unnecessary garbage collection. Doing this on every render, especially in lists or frequently updated dashboards, degrades frontend performance.
📊 Impact: Reduces CPU overhead during re-renders by reusing formatter instances, leading to smoother UI updates and less garbage collection.
🔬 Measurement: Verify by checking that the components still format numbers and currency correctly. You can profile the application during component updates to observe a reduction in time spent in formatting logic.

---
*PR created automatically by Jules for task [1832289684787129264](https://jules.google.com/task/1832289684787129264) started by @servathadi*