### PR TITLE
Add reusable WordPress sync plugin

### DIFF
--- a/inkwell.config.ts
+++ b/inkwell.config.ts
@@ -193,7 +193,7 @@ export const config = {
     'diagnostics', 'discovery', 'payments', 'onboarding',
     'notifications', 'analytics', 'auth', 'automation',
     'courses', 'crm', 'feedback', 'media',
-    'organism', 'questionnaire', 'seo', 'sync', 'agency', 'bounty',
+    'organism', 'questionnaire', 'seo', 'sync', 'wordpress-sync', 'agency', 'bounty',
   ],
 } as const
 

--- a/kernel/__tests__/plugin-loader.test.ts
+++ b/kernel/__tests__/plugin-loader.test.ts
@@ -6,6 +6,7 @@ import {
   getActivePlugins,
   collectMcpTools,
   collectDashboardWidgets,
+  runScheduledPluginHooks,
   mergePluginConfigs,
   clearPlugins,
 } from '../plugin-loader'
@@ -118,6 +119,40 @@ describe('plugin-loader', () => {
 
       const widgets = collectDashboardWidgets(['dashboard', 'notifications'])
       expect(widgets).toEqual(['TaskBoard', 'WalletView', 'NotificationBell'])
+    })
+  })
+
+  describe('runScheduledPluginHooks', () => {
+    it('runs scheduled hooks for active plugins only', async () => {
+      registerPlugin(makePlugin({
+        name: 'wordpress-sync',
+        scheduled: async () => ({ synced: 2 }),
+      }))
+      registerPlugin(makePlugin({
+        name: 'inactive',
+        scheduled: async () => ({ synced: 99 }),
+      }))
+
+      const results = await runScheduledPluginHooks(['wordpress-sync'], {}, {}, {})
+
+      expect(results).toEqual([
+        { plugin: 'wordpress-sync', ok: true, result: { synced: 2 } },
+      ])
+    })
+
+    it('captures scheduled hook failures without throwing', async () => {
+      registerPlugin(makePlugin({
+        name: 'broken',
+        scheduled: async () => {
+          throw new Error('boom')
+        },
+      }))
+
+      const results = await runScheduledPluginHooks(['broken'], {}, {}, {})
+
+      expect(results).toEqual([
+        { plugin: 'broken', ok: false, error: 'boom' },
+      ])
     })
   })
 

--- a/kernel/plugin-loader.ts
+++ b/kernel/plugin-loader.ts
@@ -58,6 +58,33 @@ export function collectDashboardWidgets(activeNames: string[]): string[] {
   return widgets
 }
 
+/** Run scheduled hooks for active plugins and return their results. */
+export async function runScheduledPluginHooks(
+  activeNames: string[],
+  event: unknown,
+  env: unknown,
+  ctx: unknown,
+): Promise<Array<{ plugin: string; ok: boolean; result?: unknown; error?: string }>> {
+  const results: Array<{ plugin: string; ok: boolean; result?: unknown; error?: string }> = []
+
+  for (const plugin of getActivePlugins(activeNames)) {
+    if (!plugin.scheduled) continue
+
+    try {
+      const result = await plugin.scheduled(event, env, ctx)
+      results.push({ plugin: plugin.name, ok: true, result })
+    } catch (error) {
+      results.push({
+        plugin: plugin.name,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  return results
+}
+
 /** Get merged config defaults from all active plugins. */
 export function mergePluginConfigs(activeNames: string[]): Record<string, unknown> {
   const merged: Record<string, unknown> = {}

--- a/kernel/types.ts
+++ b/kernel/types.ts
@@ -42,6 +42,9 @@ export interface PluginManifest {
   /** Worker routes this plugin adds — mounts routes on the shared Hono app */
   mountRoutes?: (app: HonoApp) => void
 
+  /** Scheduled Worker hook for connector syncs, maintenance, and background jobs */
+  scheduled?: (event: unknown, env: unknown, ctx: unknown) => Promise<unknown>
+
   /** MCP tools this plugin registers on the /mcp endpoint */
   mcpTools?: McpToolDef[]
 

--- a/plugins/wordpress-sync/README.md
+++ b/plugins/wordpress-sync/README.md
@@ -1,0 +1,33 @@
+# WordPress Sync Plugin
+
+Mirrors published WordPress posts and pages into Inkwell.
+
+## What it owns
+
+- Fetching WordPress REST content.
+- Normalizing content into Inkwell markdown plus frontmatter.
+- Writing `CONTENT` KV keys.
+- Upserting `DB_ANALYTICS.content_index` rows.
+- Tracking connector accounts and runs in `DB_MARKETING`.
+
+## Configuration
+
+Required:
+
+- `WORDPRESS_SITE_URL`
+
+Optional:
+
+- `WORDPRESS_CUSTOMER_SLUG`
+- `WORDPRESS_AUTH_HEADER`
+- `WORDPRESS_USERNAME`
+- `WORDPRESS_APP_PASSWORD`
+
+## Interfaces
+
+- Scheduled hook: runs when the Inkwell Worker cron runs.
+- MCP tool: `sync_wordpress_content`
+- Admin routes:
+  - `POST /api/wordpress-sync/run`
+  - `GET /api/wordpress-sync/runs`
+

--- a/plugins/wordpress-sync/index.ts
+++ b/plugins/wordpress-sync/index.ts
@@ -1,0 +1,3 @@
+export { default as manifest } from './manifest'
+export { syncWordPressContent } from './sync'
+

--- a/plugins/wordpress-sync/manifest.ts
+++ b/plugins/wordpress-sync/manifest.ts
@@ -1,0 +1,28 @@
+import type { PluginManifest, HonoApp } from '../../kernel/types'
+import type { Env } from '../types'
+import { wordpressSyncMcpTools } from './mcp-tools'
+import { wordpressSyncRoutes } from './routes'
+import { syncWordPressContent } from './sync'
+
+const wordpressSyncPlugin: PluginManifest = {
+  name: 'wordpress-sync',
+  version: '1.0.0',
+  description: 'Mirror published WordPress content into Inkwell CONTENT and content_index.',
+  requiredRole: 'admin',
+  mcpTools: wordpressSyncMcpTools,
+
+  mountRoutes: (app: HonoApp) => {
+    app.route('/api/wordpress-sync', wordpressSyncRoutes)
+  },
+
+  scheduled: async (_event, env) => syncWordPressContent(env as Env),
+
+  configDefaults: {
+    wordpressSync: {
+      enabled: true,
+    },
+  },
+}
+
+export default wordpressSyncPlugin
+

--- a/plugins/wordpress-sync/mcp-tools.ts
+++ b/plugins/wordpress-sync/mcp-tools.ts
@@ -1,0 +1,16 @@
+import type { McpToolDef } from '../../kernel/types'
+import type { Env } from '../types'
+import { syncWordPressContent } from './sync'
+
+export const wordpressSyncMcpTools: McpToolDef[] = [
+  {
+    name: 'sync_wordpress_content',
+    description: 'Mirror published WordPress posts and pages into Inkwell content storage.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    handler: async (_args, rawEnv) => syncWordPressContent(rawEnv as Env),
+  },
+]
+

--- a/plugins/wordpress-sync/routes.ts
+++ b/plugins/wordpress-sync/routes.ts
@@ -1,0 +1,26 @@
+import { Hono } from 'hono'
+import { requireAuth } from '../middleware'
+import type { AppBindings } from '../types'
+import { syncWordPressContent } from './sync'
+
+const wordpressSyncRoutes = new Hono<AppBindings>()
+
+wordpressSyncRoutes.post('/run', requireAuth, async (c) => {
+  const result = await syncWordPressContent(c.env)
+  return c.json(result, result.ok ? 200 : 500)
+})
+
+wordpressSyncRoutes.get('/runs', requireAuth, async (c) => {
+  const rows = await c.env.DB_MARKETING.prepare(
+    `SELECT id, customer_slug, connector_type, status, started_at, finished_at, records_written, cursor_json, error_message
+     FROM connector_runs
+     WHERE connector_type = 'wordpress'
+     ORDER BY started_at DESC
+     LIMIT 20`,
+  ).all()
+
+  return c.json({ runs: rows.results ?? [] })
+})
+
+export { wordpressSyncRoutes }
+

--- a/plugins/wordpress-sync/sync.ts
+++ b/plugins/wordpress-sync/sync.ts
@@ -1,0 +1,475 @@
+import type { Env } from '../types'
+
+type WordPressKind = 'post' | 'page'
+
+interface WordPressText {
+  rendered?: string
+}
+
+interface WordPressEmbeddedAuthor {
+  name?: string
+}
+
+interface WordPressEmbeddedMedia {
+  source_url?: string
+}
+
+interface WordPressEmbeddedTerm {
+  name?: string
+}
+
+interface WordPressItem {
+  id: number
+  slug: string
+  link: string
+  title?: WordPressText
+  content?: WordPressText
+  excerpt?: WordPressText
+  date?: string
+  modified?: string
+  _embedded?: {
+    author?: WordPressEmbeddedAuthor[]
+    'wp:featuredmedia'?: WordPressEmbeddedMedia[]
+    'wp:term'?: WordPressEmbeddedTerm[][]
+  }
+}
+
+interface SyncedWordPressItem {
+  slug: string
+  title: string
+  type: 'wordpress-post' | 'wordpress-page'
+  author: string
+  tags: string[]
+  description: string
+  publishedAt: string
+  updatedAt: string
+  wordCount: number
+  sourceUrl: string
+  sourceId: number
+  sourceKind: WordPressKind
+  sourceSlug: string
+  featuredImage?: string
+  markdown: string
+  meta: Record<string, unknown>
+}
+
+export interface WordPressSyncSummary {
+  ok: boolean
+  skipped?: boolean
+  reason?: string
+  sourceUrl?: string
+  customerSlug?: string
+  posts?: number
+  pages?: number
+  upserted?: number
+  deleted?: number
+  connectorRunId?: string
+  error?: string
+  warnings?: string[]
+}
+
+function normalizeSlug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120)
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value)
+}
+
+function wordCount(value: string): number {
+  const text = stripHtml(value)
+  if (!text) return 0
+  return text.split(/\s+/).filter(Boolean).length
+}
+
+function collectTerms(item: WordPressItem): string[] {
+  const values = new Set<string>()
+  for (const group of item._embedded?.['wp:term'] ?? []) {
+    for (const term of group) {
+      const cleaned = term.name?.trim()
+      if (cleaned) values.add(cleaned)
+    }
+  }
+  return Array.from(values).slice(0, 12)
+}
+
+function collectAuthor(item: WordPressItem): string {
+  return item._embedded?.author?.[0]?.name?.trim() || 'WordPress'
+}
+
+function buildSourceSlug(hostname: string, kind: WordPressKind, id: number, slug: string): string {
+  const prefix = normalizeSlug(hostname.replace(/^www\./, ''))
+  return normalizeSlug(`wp-${prefix}-${kind}-${id}-${slug}`)
+}
+
+function buildFrontmatter(item: SyncedWordPressItem): string {
+  const tags = item.tags.map((tag) => yamlString(tag)).join(', ')
+  const lines = [
+    `title: ${yamlString(item.title)}`,
+    `date: ${yamlString(item.publishedAt)}`,
+    `updated: ${yamlString(item.updatedAt)}`,
+    `author: ${yamlString(item.author)}`,
+    `tags: [${tags}]`,
+    `description: ${yamlString(item.description)}`,
+    `status: ${yamlString('published')}`,
+    `source_system: ${yamlString('wordpress')}`,
+    `source_url: ${yamlString(item.sourceUrl)}`,
+    `source_id: ${yamlString(String(item.sourceId))}`,
+    `source_kind: ${yamlString(item.sourceKind)}`,
+    `source_slug: ${yamlString(item.sourceSlug)}`,
+  ]
+
+  if (item.featuredImage) {
+    lines.push(`featured_image: ${yamlString(item.featuredImage)}`)
+  }
+
+  return `---\n${lines.join('\n')}\n---`
+}
+
+function normalizeWordPressItem(hostname: string, kind: WordPressKind, item: WordPressItem): SyncedWordPressItem {
+  const title = stripHtml(item.title?.rendered ?? item.slug)
+  const body = item.content?.rendered ?? ''
+  const excerpt = item.excerpt?.rendered ? stripHtml(item.excerpt.rendered) : ''
+  const description = (excerpt || stripHtml(body) || title).slice(0, 240)
+  const publishedAt = item.date || item.modified || new Date().toISOString()
+  const updatedAt = item.modified || item.date || publishedAt
+  const tags = collectTerms(item)
+  const author = collectAuthor(item)
+  const sourceUrl = item.link
+  const featuredImage = item._embedded?.['wp:featuredmedia']?.[0]?.source_url?.trim() || undefined
+  const wordTotal = wordCount(body)
+
+  const itemBase: Omit<SyncedWordPressItem, 'markdown' | 'meta'> = {
+    slug: buildSourceSlug(hostname, kind, item.id, item.slug),
+    title,
+    type: kind === 'post' ? 'wordpress-post' : 'wordpress-page',
+    author,
+    tags,
+    description,
+    publishedAt,
+    updatedAt,
+    wordCount: wordTotal,
+    sourceUrl,
+    sourceId: item.id,
+    sourceKind: kind,
+    sourceSlug: item.slug,
+    featuredImage,
+  }
+
+  const meta: Record<string, unknown> = {
+    title,
+    slug: itemBase.slug,
+    author,
+    tags,
+    description,
+    date: publishedAt.slice(0, 10),
+    updated: updatedAt,
+    status: 'published',
+    source_system: 'wordpress',
+    source_url: sourceUrl,
+    source_id: item.id,
+    source_kind: kind,
+    source_slug: item.slug,
+    word_count: wordTotal,
+  }
+
+  if (featuredImage) {
+    meta.featured_image = featuredImage
+  }
+
+  const markdown = `${buildFrontmatter({ ...itemBase, markdown: '', meta: {} })}\n\n${body.trim() || `<!-- Empty WordPress content for ${title} -->`}`
+  return { ...itemBase, markdown, meta }
+}
+
+function buildAuthHeader(env: Env): string | null {
+  const rawHeader = env.WORDPRESS_AUTH_HEADER?.trim()
+  if (rawHeader) return rawHeader
+
+  const username = env.WORDPRESS_USERNAME?.trim()
+  const appPassword = env.WORDPRESS_APP_PASSWORD?.trim()
+  if (!username || !appPassword) return null
+
+  return `Basic ${btoa(`${username}:${appPassword}`)}`
+}
+
+async function fetchWordPressCollection(
+  siteUrl: string,
+  kind: WordPressKind,
+  authHeader: string | null,
+  fetchImpl: typeof fetch,
+): Promise<WordPressItem[]> {
+  const items: WordPressItem[] = []
+  let page = 1
+  let totalPages = 1
+  const fields = [
+    'id',
+    'slug',
+    'link',
+    'title',
+    'content',
+    'excerpt',
+    'date',
+    'modified',
+    '_embedded',
+  ].join(',')
+
+  do {
+    const url = new URL(`/wp-json/wp/v2/${kind}s`, siteUrl)
+    url.searchParams.set('context', 'view')
+    url.searchParams.set('status', 'publish')
+    url.searchParams.set('orderby', 'modified')
+    url.searchParams.set('order', 'asc')
+    url.searchParams.set('per_page', '100')
+    url.searchParams.set('page', String(page))
+    url.searchParams.set('_embed', '1')
+    url.searchParams.set('_fields', fields)
+
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'User-Agent': 'Mozilla/5.0 (compatible; InkwellWordPressSync/1.0)',
+    }
+    if (authHeader) headers.Authorization = authHeader
+
+    const response = await fetchImpl(url, { headers })
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      throw new Error(`WordPress ${kind} sync failed (${response.status}): ${text || response.statusText}`)
+    }
+
+    items.push(...await response.json() as WordPressItem[])
+    const headerPages = Number.parseInt(response.headers.get('X-WP-TotalPages') ?? '1', 10)
+    totalPages = Number.isFinite(headerPages) && headerPages > 0 ? headerPages : 1
+    page += 1
+  } while (page <= totalPages)
+
+  return items
+}
+
+async function seedConnectorAccount(env: Env, customerSlug: string, connectorAccountId: string, siteUrl: string): Promise<void> {
+  await env.DB_MARKETING.prepare(
+    `INSERT INTO connector_accounts (id, customer_slug, connector_type, external_account_id, status, config_json, last_synced_at)
+     VALUES (?, ?, 'wordpress', ?, 'active', ?, datetime('now'))
+     ON CONFLICT(id) DO UPDATE SET
+       customer_slug = excluded.customer_slug,
+       connector_type = excluded.connector_type,
+       external_account_id = excluded.external_account_id,
+       status = excluded.status,
+       config_json = excluded.config_json,
+       last_synced_at = excluded.last_synced_at,
+       updated_at = CURRENT_TIMESTAMP`,
+  ).bind(connectorAccountId, customerSlug, siteUrl, JSON.stringify({ siteUrl })).run()
+}
+
+async function createConnectorRun(env: Env, id: string, customerSlug: string, connectorAccountId: string, startedAt: string): Promise<void> {
+  await env.DB_MARKETING.prepare(
+    `INSERT INTO connector_runs (
+       id, customer_slug, connector_type, connector_account_id, status, started_at, records_written, cursor_json, metadata_json
+     ) VALUES (?, ?, 'wordpress', ?, 'running', ?, 0, ?, ?)`,
+  ).bind(
+    id,
+    customerSlug,
+    connectorAccountId,
+    startedAt,
+    JSON.stringify({ started_at: startedAt }),
+    JSON.stringify({ site: 'wordpress' }),
+  ).run()
+}
+
+async function finalizeConnectorRun(
+  env: Env,
+  id: string,
+  status: 'completed' | 'failed',
+  recordsWritten: number,
+  cursor: Record<string, unknown>,
+  metadata: Record<string, unknown>,
+  errorMessage?: string,
+): Promise<void> {
+  await env.DB_MARKETING.prepare(
+    `UPDATE connector_runs
+     SET status = ?, records_written = ?, finished_at = ?, cursor_json = ?, metadata_json = ?, error_message = ?
+     WHERE id = ?`,
+  ).bind(status, recordsWritten, new Date().toISOString(), JSON.stringify(cursor), JSON.stringify(metadata), errorMessage ?? null, id).run()
+}
+
+async function upsertWordPressContent(env: Env, customerSlug: string, item: SyncedWordPressItem, connectorRunId: string): Promise<void> {
+  await env.CONTENT.put(`post:${item.slug}`, item.markdown)
+  await env.CONTENT.put(`meta:${item.slug}`, JSON.stringify(item.meta))
+
+  await env.DB_ANALYTICS.prepare(
+    `INSERT OR REPLACE INTO content_index (
+      slug, title, type, lang, author, tags, description, published_at, updated_at, word_count
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).bind(
+    item.slug,
+    item.title,
+    item.type,
+    'en',
+    item.author,
+    JSON.stringify(item.tags),
+    item.description,
+    item.publishedAt,
+    item.updatedAt,
+    item.wordCount,
+  ).run()
+
+  try {
+    await env.DB_MARKETING.prepare(
+      `INSERT OR REPLACE INTO marketing_snapshots (
+        id, customer_slug, connector_type, metric_scope, metric_name, dimension_key, dimension_value,
+        period_start, period_end, value_numeric, value_text, payload_json, observed_at, connector_run_id
+      ) VALUES (?, ?, 'wordpress', 'content', 'sync_item', ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      `wp-${customerSlug}-${item.slug}`,
+      customerSlug,
+      item.slug,
+      item.sourceUrl,
+      item.publishedAt,
+      item.updatedAt,
+      item.wordCount,
+      item.title,
+      JSON.stringify(item.meta),
+      new Date().toISOString(),
+      connectorRunId,
+    ).run()
+  } catch {
+    // Best-effort telemetry only.
+  }
+}
+
+async function deleteWordPressContent(env: Env, slug: string): Promise<void> {
+  await env.CONTENT.delete(`post:${slug}`)
+  await env.CONTENT.delete(`meta:${slug}`)
+  await env.DB_ANALYTICS.prepare(
+    `DELETE FROM content_index WHERE slug = ? AND type IN ('wordpress-post', 'wordpress-page')`,
+  ).bind(slug).run()
+}
+
+async function listExistingWordPressSlugs(env: Env): Promise<string[]> {
+  try {
+    const rows = await env.DB_ANALYTICS.prepare(
+      `SELECT slug FROM content_index WHERE type IN ('wordpress-post', 'wordpress-page')`,
+    ).all<{ slug: string }>()
+    return (rows.results ?? []).map((row) => row.slug)
+  } catch {
+    return []
+  }
+}
+
+export async function syncWordPressContent(env: Env, fetchImpl: typeof fetch = fetch): Promise<WordPressSyncSummary> {
+  const siteUrl = env.WORDPRESS_SITE_URL?.trim()
+  if (!siteUrl) return { ok: false, skipped: true, reason: 'WORDPRESS_SITE_URL not configured' }
+
+  const startedAt = new Date().toISOString()
+  const customerSlug = env.WORDPRESS_CUSTOMER_SLUG?.trim() || normalizeSlug(new URL(env.SITE_URL).hostname.split('.')[0] ?? 'default')
+  const connectorAccountId = `wordpress:${new URL(siteUrl).hostname}`
+  const connectorRunId = `wp-sync-${crypto.randomUUID()}`
+  const authHeader = buildAuthHeader(env)
+
+  try {
+    await seedConnectorAccount(env, customerSlug, connectorAccountId, siteUrl)
+    await createConnectorRun(env, connectorRunId, customerSlug, connectorAccountId, startedAt)
+
+    const warnings: string[] = []
+    let posts: WordPressItem[] = []
+    let pages: WordPressItem[] = []
+
+    try {
+      posts = await fetchWordPressCollection(siteUrl, 'post', authHeader, fetchImpl)
+    } catch (error) {
+      warnings.push(error instanceof Error ? error.message : `post sync failed: ${String(error)}`)
+    }
+
+    try {
+      pages = await fetchWordPressCollection(siteUrl, 'page', authHeader, fetchImpl)
+    } catch (error) {
+      warnings.push(error instanceof Error ? error.message : `page sync failed: ${String(error)}`)
+    }
+
+    if (posts.length === 0 && pages.length === 0) {
+      throw new Error(warnings[0] || 'WordPress sync returned no content')
+    }
+
+    const hostname = new URL(siteUrl).hostname
+    const normalized = [
+      ...posts.map((item) => normalizeWordPressItem(hostname, 'post', item)),
+      ...pages.map((item) => normalizeWordPressItem(hostname, 'page', item)),
+    ]
+
+    let upserted = 0
+    for (const item of normalized) {
+      await upsertWordPressContent(env, customerSlug, item, connectorRunId)
+      upserted += 1
+    }
+
+    const existingSlugs = await listExistingWordPressSlugs(env)
+    const currentSlugs = new Set(normalized.map((item) => item.slug))
+    let deleted = 0
+    for (const slug of existingSlugs) {
+      if (currentSlugs.has(slug)) continue
+      await deleteWordPressContent(env, slug)
+      deleted += 1
+    }
+
+    await finalizeConnectorRun(
+      env,
+      connectorRunId,
+      'completed',
+      upserted,
+      { last_synced_at: new Date().toISOString(), source: siteUrl, posts: posts.length, pages: pages.length, upserted, deleted, warnings },
+      { sync_scope: 'published-content', source: siteUrl, posts: posts.length, pages: pages.length, deleted, warnings },
+    )
+
+    await env.DB_MARKETING.prepare(
+      `UPDATE connector_accounts SET last_synced_at = datetime('now'), updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    ).bind(connectorAccountId).run()
+
+    return {
+      ok: true,
+      sourceUrl: siteUrl,
+      customerSlug,
+      posts: posts.length,
+      pages: pages.length,
+      upserted,
+      deleted,
+      connectorRunId,
+      warnings: warnings.length ? warnings : undefined,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    try {
+      await finalizeConnectorRun(
+        env,
+        connectorRunId,
+        'failed',
+        0,
+        { source: siteUrl, failed_at: new Date().toISOString() },
+        { sync_scope: 'published-content', source: siteUrl, error: message },
+        message,
+      )
+    } catch {
+      // Best-effort logging only.
+    }
+
+    return { ok: false, sourceUrl: siteUrl, customerSlug, error: message, connectorRunId }
+  }
+}
+

--- a/workers/inkwell-api/src/index.ts
+++ b/workers/inkwell-api/src/index.ts
@@ -19,6 +19,7 @@ import onboardingManifest from '../../../plugins/onboarding/manifest'
 import notificationsManifest from '../../../plugins/notifications/manifest'
 import bountyManifest from '../../../plugins/bounty/manifest'
 import automationManifest from '../../../plugins/automation/manifest'
+import wordpressSyncManifest from '../../../plugins/wordpress-sync/manifest'
 
 // Register all available plugins
 registerPlugin(dashboardManifest)
@@ -35,6 +36,7 @@ registerPlugin(onboardingManifest)
 registerPlugin(notificationsManifest)
 registerPlugin(bountyManifest)
 registerPlugin(automationManifest)
+registerPlugin(wordpressSyncManifest)
 
 import { analyticsRoutes } from './routes/analytics'
 import { authRoutes } from './routes/auth'
@@ -58,6 +60,7 @@ import { identityRoutes } from './routes/identity'
 import { questionnaireRoutes } from './routes/questionnaire'
 import { telegramRoutes } from './routes/telegram'
 import { bountyRoutes } from '../../../plugins/bounty/routes'
+import { wordpressSyncRoutes } from '../../../plugins/wordpress-sync/routes'
 import { auditLogger } from './middleware/audit'
 import { adapterMiddleware } from './middleware/adapters'
 import { dynamicRobotsTxt } from './middleware/edge-seo'
@@ -233,6 +236,9 @@ app.route('/api/telegram', telegramRoutes)
 
 app.use('/api/bounties/*', routeGate('bounty'))
 app.route('/api/bounties', bountyRoutes)
+
+app.use('/api/wordpress-sync/*', routeGate('wordpress-sync'))
+app.route('/api/wordpress-sync', wordpressSyncRoutes)
 
 app.route('/api/portal', portalRoutes)
 app.route('/api/portal/identity', identityRoutes)

--- a/workers/inkwell-api/src/scheduled.ts
+++ b/workers/inkwell-api/src/scheduled.ts
@@ -18,6 +18,7 @@ import { D1DatabaseAdapter } from '../../../kernel/adapters/d1'
 import { D1GraphAdapter } from '../../../kernel/adapters/d1-graph'
 import { KVContentAdapter } from '../../../kernel/adapters/kv-content'
 import { CfFeedbackAdapter } from '../../../kernel/adapters/cf-feedback'
+import { runScheduledPluginHooks } from '../../../kernel/plugin-loader'
 import { config } from '../../../inkwell.config'
 
 interface NormalizedMetric {
@@ -344,6 +345,20 @@ export async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionC
     }
   } catch (e) {
     console.error('[flywheel] Content sync failed:', e)
+  }
+
+  // Run enabled plugin maintenance and connector hooks.
+  try {
+    const pluginResults = await runScheduledPluginHooks([...config.plugins], event, env, ctx)
+    for (const result of pluginResults) {
+      if (result.ok) {
+        console.info(`[flywheel] Plugin scheduled hook completed: ${result.plugin}`)
+      } else {
+        console.error(`[flywheel] Plugin scheduled hook failed: ${result.plugin}: ${result.error}`)
+      }
+    }
+  } catch (e) {
+    console.error('[flywheel] Plugin scheduled hooks failed:', e)
   }
 
   // ── Feedback classification — LLM-powered auto-tagging ──────────────

--- a/workers/inkwell-api/src/types.ts
+++ b/workers/inkwell-api/src/types.ts
@@ -30,6 +30,11 @@ export interface Env {
   GSC_SITE_URL?: string       // e.g. "https://example.com/"
   GA4_CREDENTIALS?: string    // JSON: {client_id, client_secret, refresh_token}
   GA4_PROPERTY_ID?: string    // e.g. "123456789"
+  WORDPRESS_SITE_URL?: string // e.g. "https://example.com"
+  WORDPRESS_CUSTOMER_SLUG?: string // e.g. "default"
+  WORDPRESS_AUTH_HEADER?: string // Optional raw Authorization header for private sync
+  WORDPRESS_USERNAME?: string // Optional WordPress application password username
+  WORDPRESS_APP_PASSWORD?: string // Optional WordPress application password
   CONTRACT_AUTH_TOKEN?: string // Bearer token for milestone update endpoint
   // Twilio SMS
   TWILIO_ACCOUNT_SID?: string

--- a/workers/inkwell-api/wrangler.toml
+++ b/workers/inkwell-api/wrangler.toml
@@ -18,6 +18,9 @@ DATAFORSEO_PASSWORD = ""
 GA4_PROPERTY_ID = ""
 # Google Search Console site URL (must match exactly what's in GSC)
 GSC_SITE_URL = "https://example.com/"
+# WordPress Sync plugin source site. Leave empty to disable.
+WORDPRESS_SITE_URL = ""
+WORDPRESS_CUSTOMER_SLUG = "default"
 
 [[d1_databases]]
 binding = "DB_ANALYTICS"


### PR DESCRIPTION
## Summary
- add scheduled plugin hooks to the Inkwell plugin loader
- add a reusable `wordpress-sync` plugin for mirroring published WordPress posts/pages into CONTENT KV and `content_index`
- expose manual admin routes and MCP tool for WordPress sync
- register the plugin in the Worker and default config

## Validation
- `npx vitest run kernel/__tests__/plugin-loader.test.ts`
- `npx tsc --noEmit --skipLibCheck --module esnext --target es2022 --lib es2022,dom --moduleResolution bundler --allowSyntheticDefaultImports kernel/types.ts kernel/plugin-loader.ts plugins/wordpress-sync/sync.ts plugins/wordpress-sync/manifest.ts plugins/wordpress-sync/routes.ts plugins/wordpress-sync/mcp-tools.ts workers/inkwell-api/src/types.ts`

## Note
`wrangler deploy --dry-run` in a fresh checkout is currently blocked by the missing generated Astro Cloudflare entrypoint `@astrojs/cloudflare/entrypoints/server`; that appears to be an existing build setup requirement, not introduced by this plugin change.