### PR TITLE
⚡ Bolt: Optimize repeated .toLocaleString() costs with cached formatters

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-08-11 - Caching Intl formatters
  **Learning:** Creating Intl.NumberFormat and Intl.DateTimeFormat objects is computationally expensive, especially in loops and lists in React rendering.
  **Action:** Always use centralized caching utilities for formatters to prevent performance bottlenecks on the main thread.
+## 2024-11-20 - Memoization of NumberFormat
+**Learning:** Reusing `Intl.NumberFormat` by caching it or using centralized format utilities improves performance when formatting numbers multiple times (e.g., inside loops, tables, lists, or multiple KPIs), as instantiating a new formatter via `.toLocaleString()` repeatedly is expensive.
+**Action:** Use cached formatters from `src/lib/formatters.ts` rather than `toLocaleString()` inline in loops or frequent renders. Always explicitly pass the expected locale (e.g., `'en-US'`) rather than `undefined` to prevent hydration mismatches and UI inconsistencies across different environments.

--- a/plugins/bounty/components/BountyBoard.tsx
+++ b/plugins/bounty/components/BountyBoard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { getCurrencyFormatter } from '../../../src/lib/formatters'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -59,14 +60,13 @@ function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   })
 }
 
+// ⚡ Bolt: Using cached getCurrencyFormatter to avoid expensive .toLocaleString() instantiations during list renders.
 function formatReward(cents: number, currency: string): string {
-  const amount = (cents / 100).toLocaleString('en-US', {
-    style: 'currency',
-    currency: currency || 'USD',
+  const formatter = getCurrencyFormatter('en-US', currency || 'USD', {
     minimumFractionDigits: 0,
     maximumFractionDigits: 2,
   })
-  return amount
+  return formatter.format(cents / 100)
 }
 
 const STATUS_LABEL: Record<BountyStatus, string> = {

--- a/plugins/commerce/components/RevenueOverview.tsx
+++ b/plugins/commerce/components/RevenueOverview.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { getCurrencyFormatter } from '../../../src/lib/formatters'
 
 interface RevenueData {
   total_revenue_cents: number
@@ -23,8 +24,9 @@ function getApiConfig() {
   }
 }
 
+// ⚡ Bolt: Using cached getCurrencyFormatter to avoid expensive .toLocaleString() instantiations during list renders.
 function formatCents(cents: number): string {
-  return `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`
+  return getCurrencyFormatter('en-US', 'USD', { minimumFractionDigits: 2 }).format(cents / 100)
 }
 
 function KPI({ label, value, sub }: { label: string; value: string; sub?: string }) {

--- a/plugins/dashboard/components/AdminOverview.tsx
+++ b/plugins/dashboard/components/AdminOverview.tsx
@@ -7,6 +7,7 @@ import { Progress } from '../../../src/components/ui/progress'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../../src/components/ui/tabs'
 import { Separator } from '../../../src/components/ui/separator'
 import { cn } from '../../../src/lib/utils'
+import { getNumberFormatter, getCurrencyFormatter } from '../../../src/lib/formatters'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -74,8 +75,9 @@ function getApiConfig() {
   }
 }
 
+// ⚡ Bolt: Using cached getCurrencyFormatter to avoid expensive .toLocaleString() instantiations during renders.
 function formatCents(cents: number): string {
-  return `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 0 })}`
+  return getCurrencyFormatter('en-US', 'USD', { minimumFractionDigits: 0 }).format(cents / 100)
 }
 
 function timeAgo(ts: string): string {
@@ -331,7 +333,8 @@ export function AdminOverview() {
       {/* KPI Row */}
       <div className="flex flex-wrap gap-3">
         <MiniKPI title="Gross Revenue" value={formatCents(revenue.gross)} change={`${revenue.txCount} transactions`} icon="◈" variant="success" />
-        <MiniKPI title="Visitors Today" value={analytics.visitors.toLocaleString()} change={`${analytics.pageViews} page views`} icon="◆" />
+        {/* ⚡ Bolt: Use cached getNumberFormatter for metrics shown on dashboard to avoid repeated .toLocaleString() costs */}
+        <MiniKPI title="Visitors Today" value={getNumberFormatter('en-US').format(analytics.visitors)} change={`${analytics.pageViews} page views`} icon="◆" />
         <MiniKPI title="Contracts" value={String(contractStats.total)} change={`${contractStats.signed} signed, ${contractStats.pending} pending`} icon="◎" />
         <MiniKPI title="NPS Score" value={feedback.nps !== null ? String(feedback.nps) : '—'} change={`${feedback.responses} responses`} icon="◇" variant={feedback.nps !== null && feedback.nps >= 50 ? 'success' : feedback.nps !== null && feedback.nps >= 0 ? 'warning' : 'danger'} />
         <MiniKPI title="Check-In Rate" value={`${qMeta.rate}%`} change={`${qMeta.answered}/${qMeta.total}`} icon="◌" variant={qMeta.rate >= 80 ? 'success' : qMeta.rate >= 50 ? 'warning' : 'danger'} />
@@ -563,7 +566,8 @@ export function AdminOverview() {
                         <TableCell className="font-mono text-sm text-cyan-500 font-semibold">{c.reference}</TableCell>
                         <TableCell className="text-sm">{c.customer_name}</TableCell>
                         <TableCell className="text-xs text-muted-foreground">{c.destination ?? '—'}</TableCell>
-                        <TableCell className="font-mono text-sm">{c.rate ? `$${c.rate.toLocaleString()}` : '—'}</TableCell>
+                        {/* ⚡ Bolt: Use cached getCurrencyFormatter for list renders */}
+                        <TableCell className="font-mono text-sm">{c.rate ? getCurrencyFormatter('en-US', 'USD', { minimumFractionDigits: 0 }).format(c.rate) : '—'}</TableCell>
                         <TableCell><Badge variant={STATUS_BADGE[c.status] ?? 'outline'} className="text-[0.6rem]">{c.status}</Badge></TableCell>
                         <TableCell className="text-xs text-muted-foreground">{timeAgo(c.created_at)}</TableCell>
                       </TableRow>


### PR DESCRIPTION
💡 What: Refactored `AdminOverview.tsx`, `RevenueOverview.tsx`, and `BountyBoard.tsx` to replace inline `.toLocaleString()` instantiations with the cached `getCurrencyFormatter` and `getNumberFormatter` utility. Explicitly passes `'en-US'` to ensure reliable hydration and styling.
🎯 Why: Instantiating `Intl.NumberFormat` locally inside loop iterations or repeatedly rendered components introduces an unnecessary CPU tax. Using a centralized cached formatter prevents this initialization cost entirely.
📊 Impact: Considerably reduces render-blocking overhead for large dashboards containing dozens of formatted values, contributing to overall smoother list scrolling and faster component mounts.
🔬 Measurement: Verified that tests pass via `npm test` inside `workers/inkwell-api` and that `npm run build` succeeds globally. Visually confirmed frontend regressions were avoided through automated Playwright screenshotted snapshots (`verify.py`).

---
*PR created automatically by Jules for task [11356039687170829183](https://jules.google.com/task/11356039687170829183) started by @servathadi*