### PR TITLE
⚡ Bolt: Optimize N-body physics in KnowledgeGraph

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-08-11 - Caching Intl formatters
  **Learning:** Creating Intl.NumberFormat and Intl.DateTimeFormat objects is computationally expensive, especially in loops and lists in React rendering.
  **Action:** Always use centralized caching utilities for formatters to prevent performance bottlenecks on the main thread.
+## 2024-08-19 - Optimize N-body physics in React visualizations
+**Learning:** In hot loops like React requestAnimationFrame canvas renders, O(N^2) loops for physics (e.g. force-directed graph node repulsion) can cause frame drops. Applying Newton's Third Law allows computing forces for pairs symmetrically.
+**Action:** Optimize O(N^2) repulsion calculations to O(N^2 / 2) by starting the inner loop at i + 1 and applying equal and opposite forces to both node pairs.

--- a/src/components/visualization/KnowledgeGraph.tsx
+++ b/src/components/visualization/KnowledgeGraph.tsx
@@ -68,18 +68,24 @@ export function KnowledgeGraph({ nodes: initialNodes, edges }: KnowledgeGraphPro
     const { width, height } = dimensions
     const nodeMap = new Map(nodes.map((n) => [n.slug, n]))
 
-    for (const node of nodes) {
+    // ⚡ Bolt Optimization: O(N^2) -> O(N^2 / 2)
+    // Applying Newton's Third Law to calculate repulsion forces symmetrically.
+    // This halves the number of iterations in the hot loop, reducing frame drops.
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
       node.vx! += (width / 2 - node.x!) * 0.001
       node.vy! += (height / 2 - node.y!) * 0.001
 
-      for (const other of nodes) {
-        if (node.slug === other.slug) continue
+      for (let j = i + 1; j < nodes.length; j++) {
+        const other = nodes[j];
         const dx = node.x! - other.x!
         const dy = node.y! - other.y!
         const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 1)
         const force = 800 / (dist * dist)
         node.vx! += (dx / dist) * force
         node.vy! += (dy / dist) * force
+        other.vx! -= (dx / dist) * force
+        other.vy! -= (dy / dist) * force
       }
     }
 


### PR DESCRIPTION
⚡ Bolt: Optimize N-body physics in KnowledgeGraph

### 💡 What: 
Optimized the nested loop calculating force-directed node repulsion in the `KnowledgeGraph` component from O(N^2) to O(N^2 / 2) by applying Newton's Third Law (equal and opposite forces). Also added an inline comment explaining the optimization.

### 🎯 Why: 
In hot loops executed inside `requestAnimationFrame` for canvas rendering, large nested loops can block the main thread and cause noticeable frame drops. Calculating forces symmetrically avoids redundant math.

### 📊 Impact: 
Reduces repulsion calculation loop iterations by exactly 50%, saving CPU cycles on the main thread during heavy physics simulation frames.

### 🔬 Measurement: 
1. Navigate to `/explore` where the KnowledgeGraph is rendered.
2. Observe the initial node settling animation to confirm physics stability and visual equivalence.
3. Node physics should perform noticeably faster with 50+ nodes compared to before.

---
*PR created automatically by Jules for task [15553868679171895355](https://jules.google.com/task/15553868679171895355) started by @servathadi*