### PR TITLE
⚡ Bolt: Optimize N-Body force calculations to O(N^2 / 2)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-08-11 - Caching Intl formatters
  **Learning:** Creating Intl.NumberFormat and Intl.DateTimeFormat objects is computationally expensive, especially in loops and lists in React rendering.
  **Action:** Always use centralized caching utilities for formatters to prevent performance bottlenecks on the main thread.
+## 2024-08-20 - N-Body Force Calculation Optimization
+**Learning:** For force-directed graph or N-body visualizations, O(N^2) repulsion calculations can be bottlenecked by doing duplicate work for pairs.
+**Action:** Optimize O(N^2) repulsion calculations to O(N^2 / 2) by starting the inner loop at `i + 1` and applying equal and opposite forces to both node pairs according to Newton's Third Law.

--- a/src/components/visualization/KnowledgeGraph.tsx
+++ b/src/components/visualization/KnowledgeGraph.tsx
@@ -68,18 +68,25 @@ export function KnowledgeGraph({ nodes: initialNodes, edges }: KnowledgeGraphPro
     const { width, height } = dimensions
     const nodeMap = new Map(nodes.map((n) => [n.slug, n]))
 
-    for (const node of nodes) {
+    // Optimize O(N^2) repulsion calculations to O(N^2 / 2) by applying Newton's Third Law
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i]
       node.vx! += (width / 2 - node.x!) * 0.001
       node.vy! += (height / 2 - node.y!) * 0.001
 
-      for (const other of nodes) {
-        if (node.slug === other.slug) continue
+      for (let j = i + 1; j < nodes.length; j++) {
+        const other = nodes[j]
         const dx = node.x! - other.x!
         const dy = node.y! - other.y!
         const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 1)
         const force = 800 / (dist * dist)
-        node.vx! += (dx / dist) * force
-        node.vy! += (dy / dist) * force
+        const fx = (dx / dist) * force
+        const fy = (dy / dist) * force
+
+        node.vx! += fx
+        node.vy! += fy
+        other.vx! -= fx
+        other.vy! -= fy
       }
     }
 


### PR DESCRIPTION
💡 What: Refactored the nested iteration over nodes during the force-directed graph's simulation step to start the inner loop at `i + 1` instead of `0`.
🎯 Why: Force calculations in N-Body simulations often do duplicate work. By observing Newton's Third Law, when node A applies a force on node B, node B applies an equal and opposite force on node A.
📊 Impact: Reduces the number of distance and force calculations by approximately 50%, shifting the complexity from `O(N^2)` to `O(N^2 / 2)`. This leads to much smoother frame rates on large graph renders.
🔬 Measurement: Verify the change by observing `KnowledgeGraph.tsx` performance on the explore route or by profiling the `simulate()` loop runtime in JS dev tools.

---
*PR created automatically by Jules for task [5498224081606842325](https://jules.google.com/task/5498224081606842325) started by @servathadi*